### PR TITLE
Continue the script on missing word link

### DIFF
--- a/main.js
+++ b/main.js
@@ -231,7 +231,7 @@ app = {
 
 	go: () => {
 		const wordLink = $(".tool-type-img").prop("src");
-		if (wordLink !== null) {
+		if (wordLink !== "http://s0urce.io/client/img/words/template.png") {
 			if (listing.hasOwnProperty(wordLink) === true) {
 				const word = listing[wordLink];
 				log(`. Found word: [${word}]`);

--- a/main.js
+++ b/main.js
@@ -231,14 +231,20 @@ app = {
 
 	go: () => {
 		const wordLink = $(".tool-type-img").prop("src");
-		if (listing.hasOwnProperty(wordLink) === true) {
-			const word = listing[wordLink];
-			log(`. Found word: [${word}]`);
-			app.submit(word);
-			return;
+		if (wordLink !== null) {
+			if (listing.hasOwnProperty(wordLink) === true) {
+				const word = listing[wordLink];
+				log(`. Found word: [${word}]`);
+				app.submit(word);
+				return;
+			}
+			log("* Not seen, trying OCR...");
+			app.ocr(wordLink);
 		}
-		log("* Not seen, trying OCR...");
-		app.ocr(wordLink);
+		else {
+			log("* Can't find the word link...");
+			app.restart();	
+		}
 	},
 
 	submit: (word) => {


### PR DESCRIPTION
On rare occasions, the script picks the same victim and the same port twice in a row which causes the bot to not found the word link.

PS: Great job!